### PR TITLE
Added compatibility for wepay iframes

### DIFF
--- a/lib/generators/wepay_rails/install/templates/create_wepay_checkout_records.rb
+++ b/lib/generators/wepay_rails/install/templates/create_wepay_checkout_records.rb
@@ -27,6 +27,7 @@ class CreateWepayCheckoutRecords < ActiveRecord::Migration
             t.decimal :tax
             t.string :security_token
             t.string :access_token
+            t.string :mode
 
             t.timestamps
         end

--- a/lib/helpers/controller_helpers.rb
+++ b/lib/helpers/controller_helpers.rb
@@ -37,7 +37,7 @@ module WepayRails
       # :require_shipping	No	A boolean value (0 or 1). If set to 1 then the payer will be asked to enter a shipping address when they pay. After payment you can retrieve this shipping address by calling /checkout
       # :shipping_fee	No	The amount that you want to charge for shipping.
       # :charge_tax	No	A boolean value (0 or 1). If set to 1 and the account has a relevant tax entry (see /account/set_tax), then tax will be charged.
-      def init_checkout_and_send_user_to_wepay(params, access_token=nil)
+      def init_checkout(params, access_token=nil)
         wepay_gateway = WepayRails::Payments::Gateway.new(access_token)
         response      = wepay_gateway.perform_checkout(params)
 
@@ -48,13 +48,19 @@ module WepayRails
         params.merge!({
             :access_token   => wepay_gateway.access_token,
             :checkout_id    => response[:checkout_id],
-            :security_token => response[:security_token]
+            :security_token => response[:security_token],
+            :checkout_uri   => response[:checkout_uri]
         })
 
         WepayCheckoutRecord.create(params)
-
-        redirect_to response[:checkout_uri] and return
       end
+
+      def init_checkout_and_send_user_to_wepay(params, access_token=nil)
+        record = init_checkout(params, access_token)
+        redirect_to record.checkout_uri and return
+      end
+
+
     end
   end
 end


### PR DESCRIPTION
To use [wepay iframes](https://www.wepay.com/developer/tutorial/iframe), the dev needs to create a checkout without redirecting. These changes allow the dev to do so using the new `init_checkout` controller helper.

These changes are backwards compatibility with the original `init_checkout_and_send_user_to_wepay` controller helper.
